### PR TITLE
Fix for issue #6, when atom starts with no project path a warning is …

### DIFF
--- a/lib/local-settings.coffee
+++ b/lib/local-settings.coffee
@@ -56,6 +56,8 @@ module.exports =
     @defaultConfigPath = atom.config.configFilePath
     # load local config file in the current workspace
     projectPath = atom.project.getPaths()[0]
+    # Fix for issue #6 - when path is undefinied Atom throws error
+    return if projectPath == undefined
     localConfigPath = CSON.resolve path.join(projectPath, @configFileName)
     return unless localConfigPath
     CSON.readFile localConfigPath, (err, localConfigData) =>


### PR DESCRIPTION
This fixes Issue #6 

Added a condition when projectPath is undefined return so it doesn't try to path.join undefined and throw the error folks have been encountering when there is no current projectPath.
